### PR TITLE
fix(src/widgets/menu/handlekeypress.ts): fix no escape key action for MenuWidget of pattern menubar

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,5 @@
+{
+  "branches": [
+    "main"
+  ]
+}

--- a/src/widgets/menu/handleKeyPress.ts
+++ b/src/widgets/menu/handleKeyPress.ts
@@ -156,6 +156,12 @@ const handleKeyPress = (
         (document.activeElement as HTMLElement)?.click();
         break;
 
+      case 'Escape':
+        // Should close the menu and focus on the toggle button
+        lastFocusedElement.setAttribute('aria-expanded', 'false');
+        lastFocusedElement.focus();
+        break;
+
       case 'ArrowRight':
         if (currentActiveIndex === lastTabStopIndex) {
           itemList[firstTabStopIndex].focus();


### PR DESCRIPTION
fix #15